### PR TITLE
Tilføj fuld Pokédex med Infinite Scroll

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,23 +8,24 @@
         "@tanstack/react-query": "^5.85.5",
         "@tanstack/react-query-devtools": "^5.85.5",
         "@tanstack/react-router": "^1.131.28",
+        "@tanstack/react-router-devtools": "^1.131.28",
         "@tanstack/react-start": "^1.131.28",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "tailwindcss": "^4.1.12",
-        "vite": "^7.1.3"
+        "vite": "^7.1.3",
       },
       "devDependencies": {
         "@types/bun": "latest",
         "@types/react": "^19.1.12",
         "@types/react-dom": "^19.1.9",
         "@vitejs/plugin-react": "^5.0.2",
-        "vite-tsconfig-paths": "^5.1.4"
+        "vite-tsconfig-paths": "^5.1.4",
       },
       "peerDependencies": {
-        "typescript": "^5.9.2"
-      }
-    }
+        "typescript": "^5.9.2",
+      },
+    },
   },
   "packages": {
     "@ampproject/remapping": ["@ampproject/remapping@2.3.0", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw=="],
@@ -347,6 +348,8 @@
 
     "@tanstack/react-router": ["@tanstack/react-router@1.131.28", "", { "dependencies": { "@tanstack/history": "1.131.2", "@tanstack/react-store": "^0.7.0", "@tanstack/router-core": "1.131.28", "isbot": "^5.1.22", "tiny-invariant": "^1.3.3", "tiny-warning": "^1.0.3" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-vWExhrqHJuT9v+6/2DCQ4pVvPaYoLazMNw8WXiLNuzBXh1FuEoIGaW3jw3DEP0OJCmMiWtTi34NzQnakkQZlQg=="],
 
+    "@tanstack/react-router-devtools": ["@tanstack/react-router-devtools@1.131.28", "", { "dependencies": { "@tanstack/router-devtools-core": "1.131.28" }, "peerDependencies": { "@tanstack/react-router": "^1.131.28", "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-2EOxuvc2k7vT14XVEGJRuqEZhQkZ7RnHwpw2aGY6m/7xprl2elNwKtLExTntirAxE6HDokg8sRAnqvySHf1OVA=="],
+
     "@tanstack/react-start": ["@tanstack/react-start@1.131.28", "", { "dependencies": { "@tanstack/react-start-client": "1.131.28", "@tanstack/react-start-plugin": "1.131.28", "@tanstack/react-start-server": "1.131.28", "@tanstack/start-server-functions-client": "1.131.28", "@tanstack/start-server-functions-server": "1.131.2" }, "peerDependencies": { "@vitejs/plugin-react": ">=4.3.4", "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0", "vite": ">=6.0.0" } }, "sha512-EQEIwEyHwcNBrlefFo/wrgNfswoZopbnYRNZUZBn03e+eLCO5WeZyZ+77sFAJCmtfvBDKLzeEH0/Z7ceC1pMyQ=="],
 
     "@tanstack/react-start-client": ["@tanstack/react-start-client@1.131.28", "", { "dependencies": { "@tanstack/react-router": "1.131.28", "@tanstack/router-core": "1.131.28", "@tanstack/start-client-core": "1.131.28", "cookie-es": "^1.2.2", "tiny-invariant": "^1.3.3", "tiny-warning": "^1.0.3" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-eakFCFiXgTNKhplib5v67MJPsom1GfarZqq9KU7CGhSRp/RBARwNP0LsA9Xtui1FX5xRt/wU1lARtUcAMWqBQg=="],
@@ -358,6 +361,8 @@
     "@tanstack/react-store": ["@tanstack/react-store@0.7.4", "", { "dependencies": { "@tanstack/store": "0.7.4", "use-sync-external-store": "^1.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-DyG1e5Qz/c1cNLt/NdFbCA7K1QGuFXQYT6EfUltYMJoQ4LzBOGnOl5IjuxepNcRtmIKkGpmdMzdFZEkevgU9bQ=="],
 
     "@tanstack/router-core": ["@tanstack/router-core@1.131.28", "", { "dependencies": { "@tanstack/history": "1.131.2", "@tanstack/store": "^0.7.0", "cookie-es": "^1.2.2", "seroval": "^1.3.2", "seroval-plugins": "^1.3.2", "tiny-invariant": "^1.3.3", "tiny-warning": "^1.0.3" } }, "sha512-f+vdfr3WKSS/BcqgI5s4vZg9xYb7NkvIolkaMELrbz3l+khkw1aTjx8wqCHRY4dqwIAxq+iZBZtMWXA7pztGJg=="],
+
+    "@tanstack/router-devtools-core": ["@tanstack/router-devtools-core@1.131.28", "", { "dependencies": { "clsx": "^2.1.1", "goober": "^2.1.16", "solid-js": "^1.9.5" }, "peerDependencies": { "@tanstack/router-core": "^1.131.28", "csstype": "^3.0.10", "tiny-invariant": "^1.3.3" }, "optionalPeers": ["csstype"] }, "sha512-CPj8wv/00sfHm5tjUCJ44A5tWBYvui5PVstkNfEyNW/Cmo6aknMk4SHiWIa/khCbj5HGjVMWSBRn6XZixEdOxw=="],
 
     "@tanstack/router-generator": ["@tanstack/router-generator@1.131.28", "", { "dependencies": { "@tanstack/router-core": "1.131.28", "@tanstack/router-utils": "1.131.2", "@tanstack/virtual-file-routes": "1.131.2", "prettier": "^3.5.0", "recast": "^0.23.11", "source-map": "^0.7.4", "tsx": "^4.19.2", "zod": "^3.24.2" } }, "sha512-e/6+2bfKhdiAgbFh4X0fADcnS7jNr6HqmDQ8Dcx9zpIGzWnj3pi9HUfHi7kmgZvxtCv8286BdVJsC7PqgxFHJw=="],
 
@@ -534,6 +539,8 @@
     "clipboardy": ["clipboardy@4.0.0", "", { "dependencies": { "execa": "^8.0.1", "is-wsl": "^3.1.0", "is64bit": "^2.0.0" } }, "sha512-5mOlNS0mhX0707P2I0aZ2V/cmHUEO/fL7VFLqszkhUsxt7RwnmrInf/eEQKlf5GzvYeHIjT+Ov1HRfNmymlG0w=="],
 
     "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
+
+    "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
     "cluster-key-slot": ["cluster-key-slot@1.1.2", "", {}, "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA=="],
 
@@ -774,6 +781,8 @@
     "globrex": ["globrex@0.1.2", "", {}, "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg=="],
 
     "gonzales-pe": ["gonzales-pe@4.3.0", "", { "dependencies": { "minimist": "^1.2.5" }, "bin": { "gonzales": "bin/gonzales.js" } }, "sha512-otgSPpUmdWJ43VXyiNgEYE4luzHCL2pz4wQ0OnDluC6Eg4Ko3Vexy/SrSynglw/eR+OhkzmqFCZa/OFa/RgAOQ=="],
+
+    "goober": ["goober@2.1.16", "", { "peerDependencies": { "csstype": "^3.0.10" } }, "sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g=="],
 
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
@@ -1194,6 +1203,8 @@
     "slash": ["slash@5.1.0", "", {}, "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg=="],
 
     "smob": ["smob@1.5.0", "", {}, "sha512-g6T+p7QO8npa+/hNx9ohv1E5pVCmWrVCUzUXJyLdMmftX6ER0oiWY/w9knEonLpnOp6b6FenKnMfR8gqwWdwig=="],
+
+    "solid-js": ["solid-js@1.9.9", "", { "dependencies": { "csstype": "^3.1.0", "seroval": "~1.3.0", "seroval-plugins": "~1.3.0" } }, "sha512-A0ZBPJQldAeGCTW0YRYJmt7RCeh5rbFfPZ2aOttgYnctHE7HgKeHCBB/PVc2P7eOfmNXqMFFFoYYdm3S4dcbkA=="],
 
     "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
@@ -1621,6 +1632,6 @@
 
     "nitropack/h3/cookie-es": ["cookie-es@1.2.2", "", {}, "sha512-+W7VmiVINB+ywl1HGXJXmrqkOhpKrIiVZV6tQuV54ZyQC7MMuBt81Vc336GMLoHBq5hV/F9eXgt5Mnx0Rha5Fg=="],
 
-    "unstorage/chokidar/readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="]
+    "unstorage/chokidar/readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,13 +11,12 @@
     "@types/react": "^19.1.12",
     "@types/react-dom": "^19.1.9",
     "@vitejs/plugin-react": "^5.0.2",
-    "vite-tsconfig-paths": "^5.1.4"
-  },
-  "peerDependencies": {
+    "vite-tsconfig-paths": "^5.1.4",
     "typescript": "^5.9.2",
     "@tanstack/react-router-devtools": "^1.131.28",
     "@tanstack/react-query-devtools": "^5.85.5"
   },
+  "peerDependencies": {},
   "dependencies": {
     "@tailwindcss/vite": "^4.1.12",
     "@tanstack/react-query": "^5.85.5",

--- a/package.json
+++ b/package.json
@@ -14,14 +14,14 @@
     "vite-tsconfig-paths": "^5.1.4"
   },
   "peerDependencies": {
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.2",
+    "@tanstack/react-router-devtools": "^1.131.28",
+    "@tanstack/react-query-devtools": "^5.85.5"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.12",
     "@tanstack/react-query": "^5.85.5",
-    "@tanstack/react-query-devtools": "^5.85.5",
     "@tanstack/react-router": "^1.131.28",
-    "@tanstack/react-router-devtools": "^1.131.28",
     "@tanstack/react-start": "^1.131.28",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@tanstack/react-query": "^5.85.5",
     "@tanstack/react-query-devtools": "^5.85.5",
     "@tanstack/react-router": "^1.131.28",
+    "@tanstack/react-router-devtools": "^1.131.28",
     "@tanstack/react-start": "^1.131.28",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",

--- a/src/components/card.tsx
+++ b/src/components/card.tsx
@@ -15,16 +15,13 @@ export function Card({
   pokemon: { name: string; url: string },
 }) {
 
-  const { data: pokemonDetails, isLoading } = useQuery<Pokemon>({
+  const { data: pokemonDetails, isLoading, error, isError } = useQuery<Pokemon>({
     queryKey: ['pokemon', pokemon.url],
     queryFn: ({ signal }) => fetchPokemonDetails(pokemon.url, signal),
-    staleTime: 5 * 60 * 1000,
-    gcTime: 30 * 60 * 1000,
-    retry: 2,
-    refetchOnWindowFocus: false,
   });
 
   if (isLoading) return <div>Loading...</div>
+  if (isError) return <div className="text-red-500 text-sm">Fejl: {(error as Error).message}</div>
   if (!pokemonDetails) return null;
 
   return (

--- a/src/components/card.tsx
+++ b/src/components/card.tsx
@@ -1,51 +1,63 @@
 import { Pokemon } from "@/types/api";
 import { useQuery } from "@tanstack/react-query";
 
-const fetchPokemonDetails = async (url: string): Promise<Pokemon> => {
-  const response = await fetch(url);
+const fetchPokemonDetails = async (url: string, signal?: AbortSignal): Promise<Pokemon> => {
+  const response = await fetch(url, { signal });
   if (!response.ok) {
-      throw new Error('failed to fetch pokemon details');
+    throw new Error(`Failed to fetch Pokémon details (${response.status} ${response.statusText})`);
   }
   return response.json() as Promise<Pokemon>;
 };
 
-export function Card({ 
+export function Card({
   pokemon,
-}: { 
+}: {
   pokemon: { name: string; url: string },
 }) {
 
-    const { data: pokemonDetails, isLoading } = useQuery<Pokemon>({
-      queryKey: ['pokemon', pokemon.name],
-      queryFn: () => fetchPokemonDetails(pokemon.url),
-    });
-  
-    if(isLoading) return <div>Loading...</div>
-    if (!pokemonDetails) return null;
-  
-    return (
-      <div className="bg-zinc-900 rounded-lg p-4 hover:bg-zinc-800 transition-colors">
-        <img
-          src={pokemonDetails.sprites.front_default ?? "https://placehold.co/100"}
-          alt={pokemonDetails.name}
-          className="w-24 h-24 mx-auto mb-2 rounded-full"
-        />
-        <h3 className="text-lg font-semibold text-center capitalize">
-          {pokemonDetails.name}
-        </h3>
-        <p className="text-sm text-zinc-400 text-center">
-          #{pokemonDetails.id.toString().padStart(3, '0')}
-        </p>
-        <div className="flex justify-center gap-1 mt-2">
-          {pokemonDetails.types.map((type) => (
-            <span
-              key={type.type.name}
-              className="px-2 py-1 bg-zinc-800 text-xs rounded-full capitalize text-zinc-400"
-            >
-              {type.type.name}
-            </span>
-          ))}
-        </div>
+  const { data: pokemonDetails, isLoading } = useQuery<Pokemon>({
+    queryKey: ['pokemon', pokemon.url],
+    queryFn: ({ signal }) => fetchPokemonDetails(pokemon.url, signal),
+    staleTime: 5 * 60 * 1000,
+    gcTime: 30 * 60 * 1000,
+    retry: 2,
+    refetchOnWindowFocus: false,
+  });
+
+  if (isLoading) return <div>Loading...</div>
+  if (!pokemonDetails) return null;
+
+  return (
+    <div className="bg-zinc-900 rounded-lg p-4 hover:bg-zinc-800 transition-colors">
+      <img
+        src={
+          pokemonDetails.sprites.other?.['official-artwork']?.front_default
+            ?? pokemonDetails.sprites.front_default
+            ?? 'https://placehold.co/100'
+        }
+        alt={pokemonDetails.name}
+        className="w-24 h-24 mx-auto mb-2 rounded-full"
+        loading="lazy"
+        decoding="async"
+        width={96}
+        height={96}
+         />
+      <h3 className="text-lg font-semibold text-center capitalize">
+        {pokemonDetails.name}
+      </h3>
+      <p className="text-sm text-zinc-400 text-center">
+        #{pokemonDetails.id.toString().padStart(3, '0')}
+      </p>
+      <div className="flex justify-center gap-1 mt-2">
+        {pokemonDetails.types.map((type) => (
+          <span
+            key={type.type.name}
+            className="px-2 py-1 bg-zinc-800 text-xs rounded-full capitalize text-zinc-400"
+          >
+            {type.type.name}
+          </span>
+        ))}
       </div>
-    );
-  }
+    </div>
+  );
+}

--- a/src/components/card.tsx
+++ b/src/components/card.tsx
@@ -1,18 +1,19 @@
 import { Pokemon } from "@/types/api";
 import { useQuery } from "@tanstack/react-query";
 
+const fetchPokemonDetails = async (url: string): Promise<Pokemon> => {
+  const response = await fetch(url);
+  if (!response.ok) {
+      throw new Error('failed to fetch pokemon details');
+  }
+  return response.json() as Promise<Pokemon>;
+};
+
 export function Card({ 
   pokemon,
 }: { 
   pokemon: { name: string; url: string },
 }) {
-    const fetchPokemonDetails = async (url: string): Promise<Pokemon> => {
-        const response = await fetch(url);
-        if (!response.ok) {
-            throw new Error('failed to fetch pokemon details');
-        }
-        return response.json() as Promise<Pokemon>;
-    };
 
     const { data: pokemonDetails, isLoading } = useQuery<Pokemon>({
       queryKey: ['pokemon', pokemon.name],

--- a/src/components/card.tsx
+++ b/src/components/card.tsx
@@ -1,0 +1,50 @@
+import { Pokemon } from "@/types/api";
+import { useQuery } from "@tanstack/react-query";
+
+export function Card({ 
+  pokemon,
+}: { 
+  pokemon: { name: string; url: string },
+}) {
+    const fetchPokemonDetails = async (url: string): Promise<Pokemon> => {
+        const response = await fetch(url);
+        if (!response.ok) {
+            throw new Error('failed to fetch pokemon details');
+        }
+        return response.json() as Promise<Pokemon>;
+    };
+
+    const { data: pokemonDetails, isLoading } = useQuery<Pokemon>({
+      queryKey: ['pokemon', pokemon.name],
+      queryFn: () => fetchPokemonDetails(pokemon.url),
+    });
+  
+    if(isLoading) return <div>Loading...</div>
+    if (!pokemonDetails) return null;
+  
+    return (
+      <div className="bg-zinc-900 rounded-lg p-4 hover:bg-zinc-800 transition-colors">
+        <img
+          src={pokemonDetails.sprites.front_default ?? ""}
+          alt={pokemonDetails.name}
+          className="w-24 h-24 mx-auto mb-2"
+        />
+        <h3 className="text-lg font-semibold text-center capitalize">
+          {pokemonDetails.name}
+        </h3>
+        <p className="text-sm text-zinc-400 text-center">
+          #{pokemonDetails.id.toString().padStart(3, '0')}
+        </p>
+        <div className="flex justify-center gap-1 mt-2">
+          {pokemonDetails.types.map((type) => (
+            <span
+              key={type.type.name}
+              className="px-2 py-1 bg-zinc-800 text-xs rounded-full capitalize text-zinc-400"
+            >
+              {type.type.name}
+            </span>
+          ))}
+        </div>
+      </div>
+    );
+  }

--- a/src/components/card.tsx
+++ b/src/components/card.tsx
@@ -25,9 +25,9 @@ export function Card({
     return (
       <div className="bg-zinc-900 rounded-lg p-4 hover:bg-zinc-800 transition-colors">
         <img
-          src={pokemonDetails.sprites.front_default ?? ""}
+          src={pokemonDetails.sprites.front_default ?? "https://placehold.co/100"}
           alt={pokemonDetails.name}
-          className="w-24 h-24 mx-auto mb-2"
+          className="w-24 h-24 mx-auto mb-2 rounded-full"
         />
         <h3 className="text-lg font-semibold text-center capitalize">
           {pokemonDetails.name}

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -7,6 +7,7 @@ import {
 } from '@tanstack/react-router'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
+import { TanStackRouterDevtools } from '@tanstack/react-router-devtools'
 import styles from '@/index.css?url'
 
 const queryClient = new QueryClient()
@@ -54,6 +55,7 @@ function RootDocument({
         {children}
         <Scripts />
         <ReactQueryDevtools />
+        <TanStackRouterDevtools />
       </body>
     </html>
   )

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -10,7 +10,16 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import { TanStackRouterDevtools } from '@tanstack/react-router-devtools'
 import styles from '@/index.css?url'
 
-const queryClient = new QueryClient()
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 5 * 60 * 1000,
+      gcTime: 30 * 60 * 1000,
+      retry: 2,
+      refetchOnWindowFocus: false,
+    },
+  },
+})
 
 export const Route = createRootRoute({
   head: () => ({

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -7,7 +7,7 @@ export const Route = createFileRoute('/')({
 })
 function RouteComponent() {
   const { data, error } = useQuery<Pokemon>({
-    queryKey: ['pokemon', 1],
+    queryKey: ['pokemon'],
     queryFn: () => fetch('https://pokeapi.co/api/v2/pokemon/1').then(res => res.json()) as Promise<Pokemon>
   });
 

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,18 +1,21 @@
-import { useQuery } from "@tanstack/react-query";
+import { PokemonListResponse } from "@/types/api";
+import { useInfiniteQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
-import { Pokemon } from "@/types/api";
 
 export const Route = createFileRoute('/')({
   component: RouteComponent,
 })
 function RouteComponent() {
-  const { data, error } = useQuery<Pokemon>({
+  const { data, error, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } = useInfiniteQuery({
     queryKey: ['pokemon'],
-    queryFn: () => fetch('https://pokeapi.co/api/v2/pokemon/1').then(res => res.json()) as Promise<Pokemon>
-  });
-
-  if (error) return <div>Error: {error.message}</div>
-  if (!data) return <div>Loading...</div>
-  
-  return <img src={data.sprites.front_default ?? ""} alt="" />
+    queryFn: async ({ pageParam }: { pageParam: string }): Promise<PokemonListResponse> => {
+      const response = await fetch(pageParam)
+      if(!response.ok) {
+        throw new Error('failed to fetch pokemon list')
+      }
+      return response.json()
+    },
+    initialPageParam: 'https://pokeapi.co/api/v2/pokemon?limit=20',
+    getNextPageParam: (lastPage) => lastPage.next,
+  })
 }

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,6 +1,8 @@
+import { Card } from "@/components/card";
 import { PokemonListResponse } from "@/types/api";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
+import { useEffect, useRef } from "react";
 
 export const Route = createFileRoute('/')({
   component: RouteComponent,
@@ -18,4 +20,54 @@ function RouteComponent() {
     initialPageParam: 'https://pokeapi.co/api/v2/pokemon?limit=20',
     getNextPageParam: (lastPage) => lastPage.next,
   })
+
+  // ref points to the "load more" sentinel div for infinite scroll
+  // when it comes into view, fetchNextPage is triggered
+  const loadMoreRef = useRef<HTMLDivElement>(null)
+
+  // here below is the infinite scroll implementation using intersection observer
+  useEffect(() => {
+    const observer = new IntersectionObserver((entries) => {
+      if(entries[0]?.isIntersecting && hasNextPage && !isFetchingNextPage) {
+        fetchNextPage()
+      }
+    }, { threshold: 0.1 }) // threshold triggers when 10% of the sentinel is visible
+
+    if(loadMoreRef.current) {
+      observer.observe(loadMoreRef.current)
+    }
+
+    return () => observer.disconnect()
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage])
+
+  if(error) return <div className="p-4 text-red-500">Fejl: {error.message}</div>
+  if(isLoading) return <div className="p-4 text-zinc-400">Loader...</div>
+
+  const pokemonList = data?.pages.flatMap((page) => page.results) ?? []
+
+  return (
+    <div className="p-4">
+      <h1 className="text-6xl font-bold text-center mb-8">Pokédex</h1>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+        {pokemonList.map((pokemon) => (
+          <Card key={pokemon.name} pokemon={pokemon} />
+        ))}
+
+        {/* sentinel div for infinite scroll */}
+        <div ref={loadMoreRef} className="h-20 flex items-center justify-center">
+          {isFetchingNextPage && (
+            <div className="text-zinc-400">Loader flere...</div>
+          )}
+        </div>
+
+        {/* if there is no more pokemon to load, show a message */}
+        {!hasNextPage && (
+          <div className="text-center py-8 text-zinc-400 col-span-full">
+            Du har set alle {data?.pages[0]?.count} pokémons!
+          </div>
+        )}
+      </div>
+    </div>
+  )
 }

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -12,7 +12,7 @@ function RouteComponent() {
     queryKey: ['pokemon'],
     queryFn: async ({ pageParam }: { pageParam: string }): Promise<PokemonListResponse> => {
       const response = await fetch(pageParam)
-      if(!response.ok) {
+      if (!response.ok) {
         throw new Error('failed to fetch pokemon list')
       }
       return response.json()
@@ -28,20 +28,20 @@ function RouteComponent() {
   // here below is the infinite scroll implementation using intersection observer
   useEffect(() => {
     const observer = new IntersectionObserver((entries) => {
-      if(entries[0]?.isIntersecting && hasNextPage && !isFetchingNextPage) {
+      if (entries[0]?.isIntersecting && hasNextPage && !isFetchingNextPage) {
         fetchNextPage()
       }
     }, { threshold: 0.1 }) // threshold triggers when 10% of the sentinel is visible
 
-    if(loadMoreRef.current) {
+    if (loadMoreRef.current) {
       observer.observe(loadMoreRef.current)
     }
 
     return () => observer.disconnect()
   }, [fetchNextPage, hasNextPage, isFetchingNextPage])
 
-  if(error) return <div className="p-4 text-red-500">Fejl: {error.message}</div>
-  if(isLoading) return <div className="p-4 text-zinc-400">Loader...</div>
+  if (error) return <div className="p-4 text-red-500">Fejl: {error.message}</div>
+  if (isLoading) return <div className="p-4 text-zinc-400">Loader...</div>
 
   const pokemonList = data?.pages.flatMap((page) => page.results) ?? []
 
@@ -54,18 +54,18 @@ function RouteComponent() {
           <Card key={pokemon.name} pokemon={pokemon} />
         ))}
 
-        {/* sentinel div for infinite scroll */}
-        <div ref={loadMoreRef} className="h-20 flex items-center justify-center">
-          {isFetchingNextPage && (
-            <div className="text-zinc-400">Loader flere...</div>
-          )}
-        </div>
-
         {/* if there is no more pokemon to load, show a message */}
         {!hasNextPage && (
           <div className="text-center py-8 text-zinc-400 col-span-full">
-            Du har set alle {data?.pages[0]?.count} pokémons!
+            Du har set alle {data?.pages[0]?.count} Pokémon!
           </div>
+        )}
+      </div>
+
+      {/* sentinel div for infinite scroll */}
+      <div ref={loadMoreRef} className="h-20 flex items-center justify-center">
+        {isFetchingNextPage && (
+          <div className="text-zinc-400">Loader flere...</div>
         )}
       </div>
     </div>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,7 +1,18 @@
+import { useQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
+import { Pokemon } from "@/types/api";
 
 export const Route = createFileRoute('/')({
   component: RouteComponent,
 })
+function RouteComponent() {
+  const { data, error } = useQuery<Pokemon>({
+    queryKey: ['pokemon', 1],
+    queryFn: () => fetch('https://pokeapi.co/api/v2/pokemon/1').then(res => res.json()) as Promise<Pokemon>
+  });
 
-function RouteComponent() {}
+  if (error) return <div>Error: {error.message}</div>
+  if (!data) return <div>Loading...</div>
+  
+  return <img src={data.sprites.front_default ?? ""} alt="" />
+}

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -24,11 +24,13 @@ export interface Pokemon {
     weight: number;
 }
 
+export interface NamedAPIResource {
+    name: string;
+    url: string;
+}
+
 export interface Ability {
-    ability: {
-        name: string;
-        url: string;
-    };
+    ability: NamedAPIResource;
     is_hidden: boolean;
     slot: number;
 }
@@ -40,67 +42,40 @@ export interface Form {
 
 export interface GameIndex {
     game_index: number;
-    version: {
-        name: string;
-        url: string;
-    };
+    version: NamedAPIResource;
 }
 
 export interface HeldItem {
-    item: {
-        name: string;
-        url: string;
-    };
+    item: NamedAPIResource;
     version_details: VersionDetail[];
 }
 
 export interface VersionDetail {
     rarity: number;
-    version: {
-        name: string;
-        url: string;
-    };
+    version: NamedAPIResource;
 }
 
 export interface Move {
-    move: {
-        name: string;
-        url: string;
-    };
+    move: NamedAPIResource;
     version_group_details: VersionGroupDetail[];
 }
 
 export interface VersionGroupDetail {
     level_learned_at: number;
-    move_learn_method: {
-        name: string;
-        url: string;
-    };
+    move_learn_method: NamedAPIResource;
     order: number | null;
-    version_group: {
-        name: string;
-        url: string;
-    };
+    version_group: NamedAPIResource;
 }
 
 export interface PastAbility {
-    ability: {
-        name: string;
-        url: string;
-    };
+    ability: NamedAPIResource;
     is_hidden: boolean;
     slot: number;
-    generation: {
-        name: string;
-        url: string;
-    };
+    generation: NamedAPIResource;
 }
 
 export interface PastType {
-    generation: {
-        name: string;
-        url: string;
-    };
+    generation: NamedAPIResource;
     types: Type[];
 }
 
@@ -150,18 +125,12 @@ export interface Sprites {
 export interface Stat {
     base_stat: number;
     effort: number;
-    stat: {
-        name: string;
-        url: string;
-    };
+    stat: NamedAPIResource;
 }
 
 export interface Type {
     slot: number;
-    type: {
-        name: string;
-        url: string;
-    };
+    type: NamedAPIResource;
 }
 
 export interface SpriteVersions {

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,0 +1,222 @@
+export interface Pokemon {
+    abilities: Ability[];
+    base_experience: number;
+    cries: {
+        latest: string;
+        legacy: string;
+    };
+    forms: Form[];
+    game_indices: GameIndex[];
+    height: number;
+    held_items: HeldItem[];
+    id: number;
+    is_default: boolean;
+    location_area_encounters: string;
+    moves: Move[];
+    name: string;
+    order: number;
+    past_abilities?: PastAbility[];
+    past_types?: PastType[];
+    species: Species;
+    sprites: Sprites;
+    stats: Stat[];
+    types: Type[];
+    weight: number;
+}
+
+export interface Ability {
+    ability: {
+        name: string;
+        url: string;
+    };
+    is_hidden: boolean;
+    slot: number;
+}
+
+export interface Form {
+    name: string;
+    url: string;
+}
+
+export interface GameIndex {
+    game_index: number;
+    version: {
+        name: string;
+        url: string;
+    };
+}
+
+export interface HeldItem {
+    item: {
+        name: string;
+        url: string;
+    };
+    version_details: VersionDetail[];
+}
+
+export interface VersionDetail {
+    rarity: number;
+    version: {
+        name: string;
+        url: string;
+    };
+}
+
+export interface Move {
+    move: {
+        name: string;
+        url: string;
+    };
+    version_group_details: VersionGroupDetail[];
+}
+
+export interface VersionGroupDetail {
+    level_learned_at: number;
+    move_learn_method: {
+        name: string;
+        url: string;
+    };
+    order: number | null;
+    version_group: {
+        name: string;
+        url: string;
+    };
+}
+
+export interface PastAbility {
+    ability: {
+        name: string;
+        url: string;
+    };
+    is_hidden: boolean;
+    slot: number;
+    generation: {
+        name: string;
+        url: string;
+    };
+}
+
+export interface PastType {
+    generation: {
+        name: string;
+        url: string;
+    };
+    types: Type[];
+}
+
+export interface Species {
+    name: string;
+    url: string;
+}
+
+export interface Sprites {
+    back_default: string | null;
+    back_female: string | null;
+    back_shiny: string | null;
+    back_shiny_female: string | null;
+    front_default: string | null;
+    front_female: string | null;
+    front_shiny: string | null;
+    front_shiny_female: string | null;
+    other: {
+        dream_world: {
+            front_default: string | null;
+            front_female: string | null;
+        };
+        home: {
+            front_default: string | null;
+            front_female: string | null;
+            front_shiny: string | null;
+            front_shiny_female: string | null;
+        };
+        "official-artwork": {
+            front_default: string | null;
+            front_shiny: string | null;
+        };
+        showdown: {
+            back_default: string | null;
+            back_female: string | null;
+            back_shiny: string | null;
+            back_shiny_female: string | null;
+            front_default: string | null;
+            front_female: string | null;
+            front_shiny: string | null;
+            front_shiny_female: string | null;
+        };
+    };
+    versions: SpriteVersions;
+}
+
+export interface Stat {
+    base_stat: number;
+    effort: number;
+    stat: {
+        name: string;
+        url: string;
+    };
+}
+
+export interface Type {
+    slot: number;
+    type: {
+        name: string;
+        url: string;
+    };
+}
+
+export interface SpriteVersions {
+    "generation-i": {
+        "red-blue": GenerationSprites;
+        yellow: GenerationSprites;
+    };
+    "generation-ii": {
+        crystal: GenerationSprites;
+        gold: GenerationSprites;
+        silver: GenerationSprites;
+    };
+    "generation-iii": {
+        emerald: GenerationSprites;
+        "firered-leafgreen": GenerationSprites;
+        "ruby-sapphire": GenerationSprites;
+    };
+    "generation-iv": {
+        "diamond-pearl": GenerationSprites;
+        "heartgold-soulsilver": GenerationSprites;
+        platinum: GenerationSprites;
+    };
+    "generation-v": {
+        "black-white": GenerationSpritesAnimated;
+    };
+    "generation-vi": {
+        "omegaruby-alphasapphire": GenerationSprites;
+        "x-y": GenerationSprites;
+    };
+    "generation-vii": {
+        icons: {
+            front_default: string | null;
+            front_female: string | null;
+        };
+        "ultra-sun-ultra-moon": GenerationSprites;
+    };
+    "generation-viii": {
+        icons: {
+            front_default: string | null;
+            front_female: string | null;
+        };
+    };
+}
+
+export interface GenerationSprites {
+    back_default?: string | null;
+    back_female?: string | null;
+    back_shiny?: string | null;
+    back_shiny_female?: string | null;
+    front_default: string | null;
+    front_female?: string | null;
+    front_shiny?: string | null;
+    front_shiny_female?: string | null;
+}
+
+export interface GenerationSpritesAnimated extends GenerationSprites {
+    animated: GenerationSprites;
+}

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -220,3 +220,15 @@ export interface GenerationSprites {
 export interface GenerationSpritesAnimated extends GenerationSprites {
     animated: GenerationSprites;
 }
+
+export interface PokemonListResponse {
+    count: number;
+    next: string | null;
+    previous: string | null;
+    results: PokemonListItem[];
+}
+
+export interface PokemonListItem {
+    name: string;
+    url: string;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     // Environment setup & latest features
-    "lib": ["ESNext"],
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "target": "ESNext",
     "module": "Preserve",
     "moduleDetection": "force",


### PR DESCRIPTION
Denne side henter Pokémon-data fra [PokeAPI](https://pokeapi.co/) og viser dem i et grid. Funktionen inkluderer:

- Datahåndtering med `useInfiniteQuery` fra **TanStack Query** for effektiv caching, loading states og pagination
- Infinite scroll implementeret med IntersectionObserver
- Kortvisning af Pokémon (Card-komponenter)
-Loader og fejlbeskeder
- Besked, når alle Pokémon’er er hentet

Dette er hvor jeg læste mig frem til `useInfinityQuery`.
https://tanstack.com/query/latest/docs/framework/react/guides/infinite-queries

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pokémon cards showing image, capitalized name, zero-padded ID, and type badges.
  * Infinite scrolling on the home page with automatic loading as you reach the bottom.
  * Loading indicators during fetches and a completion message when all Pokémon are shown.
  * Simple error message displayed if loading fails.

* **Chores**
  * Enabled DOM typings in TypeScript config.
  * Added comprehensive API data types for improved type safety.
  * Added router devtools for development.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->